### PR TITLE
client connection duration is now configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type config struct {
 	Concurrency       int
 	Metadata          bool
 	LogResponseErrors bool `yaml:"log_response_errors"`
+	MaxConnDuration   time.Duration `yaml:"max_connection_duration"`
 
 	Auth struct {
 		Egress struct {

--- a/processor.go
+++ b/processor.go
@@ -66,6 +66,7 @@ func newProcessor(c config) *processor {
 		MaxConnWaitTimeout: 1 * time.Second,
 		MaxConnsPerHost:    64,
 		DialDualStack:      c.EnableIPv6,
+		MaxConnDuration:    c.MaxConnDuration,
 	}
 
 	if c.Auth.Egress.Username != "" {


### PR DESCRIPTION
**Problem to solve**
 We're using cortex-tenant (with a replica of n) inside Kubernetes to push prometheus data to mimir. 
 We have several distributors (entry point of mimir) available through a kubernetes service.
 The problem is that kubernetes internal load balancer is layer 4  and cortext-tenant is keeping the tcp connection open. So there was no real load balancing at the request level. 
 At some point all requests were sent to only one mimir distributor. For example if n-1 distributor are restarted, all requests are going to be pushed to the only one which hasn't restarted (even if the other are available again)
 
 **Solution**
I've add a new configurable parameter "max_connection_duration" to set the maximum duration of the client connections (between cortex-tenant and mimir). By settings this duration for example to 60s. It force cortext-tenant to reopen a new TCP connection each 60 seconds and so to be rebalanced to a new mimir distributor 

** Here is an illustration of this change **
![image](https://user-images.githubusercontent.com/7581646/227245525-ef0a2a0f-d492-4539-8c9e-2a1aa9bf6c9e.png)
I've change the settings at 15:10
We can see that the load balancing wasn't good before but was ok after the change

