### PR TITLE
feat: add maxconnsperhosts customization variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ target: http://127.0.0.1:9091/receive
 # env: CT_ENABLE_IPV6
 enable_ipv6: false
 
+# Use this parameter when you need to improve the outgoing maximum connections to backend (mimir / cortex)
+# Generally use this parameter when you send many incomming requests which overwhelming the outgoing side to cortex-tenant (cortex / mimir etc)
 # Set max conn per host
 # env: CT_MAX_CONNS_PER_HOST
 max_conns_per_host: 64

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ target: http://127.0.0.1:9091/receive
 # env: CT_ENABLE_IPV6
 enable_ipv6: false
 
+# Set max conn per host
+# env: CT_MAX_CONNS_PER_HOST
+max_conns_per_host: 64
+
 # Authentication (optional)
 auth:
   # Egress HTTP basic auth -> add `Authentication` header to outgoing requests

--- a/config.go
+++ b/config.go
@@ -27,8 +27,8 @@ type config struct {
 	Metadata          bool          `env:"CT_METADATA"`
 	LogResponseErrors bool          `yaml:"log_response_errors" env:"CT_LOG_RESPONSE_ERRORS"`
 	MaxConnDuration   time.Duration `yaml:"max_connection_duration" env:"CT_MAX_CONN_DURATION"`
-
-	Auth struct {
+	MaxConnsPerHost   int           `env:"CT_MAX_CONNS_PER_HOST" yaml:"max_conns_per_host"`
+	Auth              struct {
 		Egress struct {
 			Username string `env:"CT_AUTH_EGRESS_USERNAME"`
 			Password string `env:"CT_AUTH_EGRESS_PASSWORD"`
@@ -102,6 +102,10 @@ func configLoad(file string) (*config, error) {
 		if cfg.Auth.Egress.Password == "" {
 			return nil, fmt.Errorf("egress auth user specified, but the password is not")
 		}
+	}
+
+	if cfg.MaxConnsPerHost == 0 {
+		cfg.MaxConnsPerHost = 64
 	}
 
 	return cfg, nil

--- a/config.go
+++ b/config.go
@@ -28,7 +28,8 @@ type config struct {
 	LogResponseErrors bool          `yaml:"log_response_errors" env:"CT_LOG_RESPONSE_ERRORS"`
 	MaxConnDuration   time.Duration `yaml:"max_connection_duration" env:"CT_MAX_CONN_DURATION"`
 	MaxConnsPerHost   int           `env:"CT_MAX_CONNS_PER_HOST" yaml:"max_conns_per_host"`
-	Auth              struct {
+
+	Auth struct {
 		Egress struct {
 			Username string `env:"CT_AUTH_EGRESS_USERNAME"`
 			Password string `env:"CT_AUTH_EGRESS_PASSWORD"`

--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ metrics_include_tenant: true
 
 target: http://127.0.0.1:9091/receive
 enable_ipv6: false
+max_conns_per_host: 64
 
 auth:
   egress:

--- a/processor.go
+++ b/processor.go
@@ -106,7 +106,7 @@ func newProcessor(c config) *processor {
 		ReadTimeout:        c.Timeout,
 		WriteTimeout:       c.Timeout,
 		MaxConnWaitTimeout: 1 * time.Second,
-		MaxConnsPerHost:    64,
+		MaxConnsPerHost:    c.MaxConnsPerHost,
 		DialDualStack:      c.EnableIPv6,
 		MaxConnDuration:    c.MaxConnDuration,
 	}

--- a/processor_test.go
+++ b/processor_test.go
@@ -26,6 +26,8 @@ log_level: debug
 timeout: 50ms
 timeout_shutdown: 100ms
 
+max_conns_per_host: 64
+
 tenant:
   label_remove: false
   default: default


### PR DESCRIPTION
Hi,

When we have more than 64 connections to cortex-tenant it indicates "no connections free to host". This is due to the maxconnsperhost configuration limitation.

I added a customization variable for tuning max connection per host.