### PR TITLE
Adding Image Pull Secrets

### DIFF
--- a/deploy/k8s/chart/templates/deployment.yaml
+++ b/deploy/k8s/chart/templates/deployment.yaml
@@ -24,13 +24,13 @@ spec:
         {{- end }}
       labels:
         {{- include "cortex-tenant.selectorLabels" . | nindent 8 }}
+    spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
         - name: {{ . }}
       {{- end }}
       {{- end }}
-    spec:
       containers:
         - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deploy/k8s/chart/templates/deployment.yaml
+++ b/deploy/k8s/chart/templates/deployment.yaml
@@ -24,6 +24,12 @@ spec:
         {{- end }}
       labels:
         {{- include "cortex-tenant.selectorLabels" . | nindent 8 }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
     spec:
       containers:
         - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -10,6 +10,11 @@ image:
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (default is `.Chart.appVersion`)
   tag: ""
+  # -- Optionally specify an array of imagePullSecrets
+  # Secrets must be manually created in the namespace.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # pullSecrets:
+  #   - myRegistryKeySecretName
 
 service:
   # -- The type of service


### PR DESCRIPTION
For images stored within a private registry, often the a secret (way of authentication) is needed. to supply this authentication way the `imagepullsecret` has been added.