### PR TITLE
add max_conns_per_host config to helm chart

### DIFF
--- a/deploy/k8s/chart/templates/configmap.yaml
+++ b/deploy/k8s/chart/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
     metadata: {{ .Values.config.metadata }}
     log_response_errors: {{ .Values.config.log_response_errors }}
     max_connection_duration: {{ .Values.config.max_connection_duration }}
+    max_conns_per_host: {{ .Values.config.max_conns_per_host }}
     {{- if .Values.config.auth.enabled }}
     auth:
       egress:

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -87,6 +87,11 @@ config:
   # Use 0 to keep them indefinitely
   # (env: `CT_MAX_CONN_DURATION`)
   max_connection_duration: 0s
+  # -- This parameter sets the limit for the count of outgoing concurrent connections to Cortex / Mimir.
+  # By default it's 64 and if all of these connections are busy you will get errors when pushing from Prometheus.
+  # If your `target` is a DNS name that resolves to several IPs then this will be a per-IP limit.
+  # (env: `CT_MAX_CONNS_PER_HOST`)
+  max_conns_per_host: 64
 
   # Authentication (optional)
   auth:


### PR DESCRIPTION
The Helm chart was missing `max_conns_per_host` as an option for cortex-tenant configs. While this could be injected in as an environment variable, might as well also add it as an explicit config option as per how the other configs are handled. :)