### PR TITLE
fix(deb-package): fix after-install.sh so user directory is actually created

### DIFF
--- a/deploy/after_install.sh
+++ b/deploy/after_install.sh
@@ -3,5 +3,5 @@
 USER="cortex-tenant"
 HOME="/var/lib/$USER"
 
-useradd -d $HOME -s /bin/false -M $USER > /dev/null 2>&1 || true
+useradd -d $HOME -s /bin/false -m $USER > /dev/null 2>&1 || true
 chown $USER:$USER $HOME


### PR DESCRIPTION
Probably a typo, the script was using useradd with option -M, which actually forbid user directory creation.