### PR TITLE
FEAT: Add IDLE_TIMEOUT config param, and update doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ log_level: warn
 # env: CT_TIMEOUT
 timeout: 10s
 
+# HTTP request idle timeout
+# env: CT_IDLE_TIMEOUT
+idle_timeout: 60s
+
 # Timeout to wait on shutdown to allow load balancers detect that we're going away.
 # During this period after the shutdown command the /alive endpoint will reply with HTTP 503.
 # Set to 0s to disable.

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type config struct {
 
 	LogLevel          string        `yaml:"log_level" env:"CT_LOG_LEVEL"`
 	Timeout           time.Duration `env:"CT_TIMEOUT"`
+	IdleTimeout       time.Duration `yaml:"idle_timeout" env:"CT_IDLE_TIMEOUT"`
 	TimeoutShutdown   time.Duration `yaml:"timeout_shutdown" env:"CT_TIMEOUT_SHUTDOWN"`
 	Concurrency       int           `env:"CT_CONCURRENCY"`
 	Metadata          bool          `env:"CT_METADATA"`
@@ -87,6 +88,10 @@ func configLoad(file string) (*config, error) {
 
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 10 * time.Second
+	}
+
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = 60 * time.Second
 	}
 
 	if cfg.Concurrency == 0 {

--- a/deploy/k8s/chart/values.schema.json
+++ b/deploy/k8s/chart/values.schema.json
@@ -195,6 +195,12 @@
           "description": "HTTP request timeout",
           "format": "duration"
         },
+        "idle_timeout": {
+          "type": "string",
+          "title": "Idle_Timeout",
+          "description": "HTTP request idle timeout",
+          "format": "duration"
+        },
         "timeout_shutdown": {
           "type": "string",
           "title": "Shutdown timeout",

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -65,6 +65,9 @@ config:
   # -- HTTP request timeout
   # (env: `CT_TIMEOUT`)
   timeout: 10s
+  # -- HTTP request idle timeout
+  # (env: `CT_IDLE_TIMEOUT`)
+  idle_timeout: 60s
   # -- Timeout to wait on shutdown to allow load balancers detect that we're going away.
   # During this period after the shutdown command the /alive endpoint will reply with HTTP 503.
   # Set to 0s to disable.

--- a/deploy/k8s/manifests/config-file-configmap.yml
+++ b/deploy/k8s/manifests/config-file-configmap.yml
@@ -17,6 +17,8 @@ data:
     log_level: warn
     # HTTP request timeout
     timeout: 10s
+    # HTTP request idle timeout
+    idle_timeout: 60s
     # Timeout to wait on shutdown to allow load balancers detect that we're going away.
     # During this period after the shutdown command the /alive endpoint will reply with HTTP 503.
     # Set to 0s to disable.

--- a/processor.go
+++ b/processor.go
@@ -97,7 +97,7 @@ func newProcessor(c config) *processor {
 
 		ReadTimeout:  c.Timeout,
 		WriteTimeout: c.Timeout,
-		IdleTimeout:  60 * time.Second,
+		IdleTimeout:  c.IdleTimeout,
 
 		Concurrency: c.Concurrency,
 	}


### PR DESCRIPTION
We have a setup where HAProxy fronts the loki/mimir servers that the cortex-tenant is connecting, and sending data to. Now the HAProxy servers have configured the client idle timeout param to 15s, so that any idle connection from anyone including cortex-tenant is purged in 15 seconds. Details https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#3.10-timeout%20client

This is clear from the cortex-tenant logs - 

```
time="2025-07-08T20:31:51Z" level=error msg="proc: src=10.185.9.101:50522 write tcp4 10.185.4.103:33906->10.178.64.210:443: write: broken pipe"
time="2025-07-08T20:31:51Z" level=error msg="proc: src=10.185.7.19:45332 write tcp4 10.185.4.103:33556->10.178.64.210:443: write: broken pipe"
time="2025-07-08T20:31:51Z" level=error msg="proc: src=10.185.7.19:45332 the server closed connection before returning the first response byte. Make sure the server returns 'Connection: close' response header before closing the connection"
```

So the proposed change in this PR adds a new idle timeout parameter in the config which grants the operator ability to tweak the idle timeout settings in the server to match that of the upstream proxy.

The change has been tested locally. 

Dear @blind-oracle (maintainers), this is my first commit to this PR. Please let me know if there are any questions/comments. 