### PR TITLE
Improve trusted CA support

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,8 +34,11 @@ type config struct {
 
 	Auth struct {
 		Egress struct {
-			Username string `env:"CT_AUTH_EGRESS_USERNAME"`
-			Password string `env:"CT_AUTH_EGRESS_PASSWORD"`
+			Username  string `env:"CT_AUTH_EGRESS_USERNAME"`
+			Password  string `env:"CT_AUTH_EGRESS_PASSWORD"`
+			TlsConfig struct {
+				CaBundleFile string `yaml:"ca_bundle_file" env:"CT_CA_BUNDLE_FILE"`
+			} `yaml:"tls_config"`
 		}
 	}
 

--- a/deploy/k8s/chart/README.md
+++ b/deploy/k8s/chart/README.md
@@ -19,6 +19,7 @@ A Helm Chart for cortex-tenant
 | autoscaling.minReplica | int | `1` | Min number of pod replica autoscaled |
 | autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilization percentage for autoscaling |
 | autoscaling.targetMemoryUtilizationPercentage | int | `60` | Target memory utilization percentage for autoscaling |
+| config.ca_bundle_file | string | `null` | If set, this file is loaded as the CA Bundle for verifying TLS certificates sent by the upstream server |
 | config.auth.enabled | bool | `false` | Egress HTTP basic auth -> add `Authentication` header to outgoing requests |
 | config.auth.existingSecret | string | `nil` | Secret should pass the `CT_AUTH_EGRESS_USERNAME` and `CT_AUTH_EGRESS_PASSWORD` env variables |
 | config.auth.password | string | `nil` | Password (env: `CT_AUTH_EGRESS_PASSWORD`) |

--- a/deploy/k8s/chart/templates/configmap.yaml
+++ b/deploy/k8s/chart/templates/configmap.yaml
@@ -18,12 +18,14 @@ data:
     log_response_errors: {{ .Values.config.log_response_errors }}
     max_connection_duration: {{ .Values.config.max_connection_duration }}
     max_conns_per_host: {{ .Values.config.max_conns_per_host }}
-    {{- if .Values.config.auth.enabled }}
     auth:
       egress:
+        tls_config:
+          ca_bundle_file: {{ .Values.config.ca_bundle_file }}
+        {{- if .Values.config.auth.enabled }}
         username: {{ .Values.config.auth.username }}
         password: {{ .Values.config.auth.password }}
-    {{- end }}
+        {{- end }}
     tenant:
       label: {{ .Values.config.tenant.label }}
       {{- with .Values.config.tenant.label_list }}

--- a/deploy/k8s/chart/templates/configmap.yaml
+++ b/deploy/k8s/chart/templates/configmap.yaml
@@ -21,7 +21,11 @@ data:
     auth:
       egress:
         tls_config:
+          {{- if .Values.customCA }}
+          ca_bundle_file: /var/run/secrets/custom-ca/ca.crt
+          {{- else }}
           ca_bundle_file: {{ .Values.config.ca_bundle_file }}
+          {{- end }}
         {{- if .Values.config.auth.enabled }}
         username: {{ .Values.config.auth.username }}
         password: {{ .Values.config.auth.password }}

--- a/deploy/k8s/chart/templates/deployment.yaml
+++ b/deploy/k8s/chart/templates/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             - mountPath: /data/
               name: config-file
             {{- if .Values.customCA }}
-            - mountPath: /etc/ssl/certs/ca-bundle.crt
+            - mountPath: /var/run/secrets/custom-ca/ca.crt
               name: ca-bundle
               subPath: {{ .Values.customCA.subPath | default "ca.crt" }}
             {{- end }}

--- a/deploy/k8s/chart/values.schema.json
+++ b/deploy/k8s/chart/values.schema.json
@@ -235,6 +235,14 @@
           "description": "Maximum number of outgoing concurrent connections to Cortex / Mimir",
           "default": 64
         },
+        "ca_bundle_file": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "title": "CA Bundle File",
+          "description": "If set, this file is loaded as the CA Bundle for verifying TLS certificates sent by the upstream server"
+        },
         "auth": {
           "type": "object",
           "title": "Authentication",

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -97,6 +97,7 @@ config:
   # (env: `CT_MAX_CONNS_PER_HOST`)
   max_conns_per_host: 64
   # -- If set this file is loaded as the CA Bundle for verifying TLS certificates sent by the upstream server.
+  # This field is ignored if customCA is set.
   # (env: `CT_CA_BUNDLE_FILE`)
   ca_bundle_file:
 
@@ -262,6 +263,7 @@ serviceMonitor:
     rules: []
 
 # -- Optionally specify an custom ca if cortex endpoint is running in a private environment with a self signed ca
+# If present, config.ca_bundle_file is overriden with the mount path of this secret.
 # customCA: {}
 #   secretName: ca-bundle
 #   subPath: ca.crt

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -96,6 +96,9 @@ config:
   # If your `target` is a DNS name that resolves to several IPs then this will be a per-IP limit.
   # (env: `CT_MAX_CONNS_PER_HOST`)
   max_conns_per_host: 64
+  # -- If set this file is loaded as the CA Bundle for verifying TLS certificates sent by the upstream server.
+  # (env: `CT_CA_BUNDLE_FILE`)
+  ca_bundle_file:
 
   # Authentication (optional)
   auth:

--- a/main.go
+++ b/main.go
@@ -52,7 +52,10 @@ func main() {
 	cfgJSON, _ := json.Marshal(cfg)
 	log.Warnf("Effective config: %+v", string(cfgJSON))
 
-	proc := newProcessor(*cfg)
+	proc, err := newProcessor(*cfg)
+	if err != nil {
+		log.Fatalf("Unable to create processor: %s", err)
+	}
 
 	if err = proc.run(); err != nil {
 		log.Fatalf("Unable to start: %s", err)

--- a/processor.go
+++ b/processor.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -11,6 +14,7 @@ import (
 
 	"github.com/blind-oracle/go-common/logger"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	fh "github.com/valyala/fasthttp"
 )
 
@@ -64,6 +68,18 @@ func newProcessor(c config) (*processor, error) {
 		MaxConnsPerHost:    c.MaxConnsPerHost,
 		DialDualStack:      c.EnableIPv6,
 		MaxConnDuration:    c.MaxConnDuration,
+		TLSConfig:          &tls.Config{},
+	}
+
+	if caFile := c.Auth.Egress.TlsConfig.CaBundleFile; caFile != "" {
+		caCert, err := ioutil.ReadFile(caFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "Unable to load CA Bundle")
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+		p.cli.TLSConfig.RootCAs = caCertPool
 	}
 
 	if c.Auth.Egress.Username != "" {

--- a/processor.go
+++ b/processor.go
@@ -37,7 +37,7 @@ type processor struct {
 	}
 }
 
-func newProcessor(c config) *processor {
+func newProcessor(c config) (*processor, error) {
 	p := &processor{
 		cfg:    c,
 		Logger: logger.NewSimpleLogger("proc"),
@@ -78,7 +78,7 @@ func newProcessor(c config) *processor {
 		}
 	}
 
-	return p
+	return p, nil
 }
 
 func (p *processor) run() (err error) {

--- a/processor_logs_test.go
+++ b/processor_logs_test.go
@@ -141,7 +141,7 @@ func Test_handle_logs(t *testing.T) {
 	cfg.pipeOut = fhu.NewInmemoryListener()
 	cfg.Tenant.LabelRemove = true
 
-	p := newProcessor(*cfg)
+	p, _ := newProcessor(*cfg)
 	err = p.run()
 	assert.Nil(t, err)
 
@@ -282,7 +282,7 @@ func Test_processStream(t *testing.T) {
 	cfg, err := getConfig(testLokiConfig)
 	assert.Nil(t, err)
 
-	p := newProcessor(*cfg)
+	p, _ := newProcessor(*cfg)
 
 	ten, err := p.processStream(&testStream3)
 	assert.Nil(t, err)
@@ -293,7 +293,7 @@ func Test_processStream(t *testing.T) {
 	assert.Equal(t, "default", ten)
 
 	cfg.Tenant.Default = ""
-	p = newProcessor(*cfg)
+	p, _ = newProcessor(*cfg)
 	assert.Nil(t, err)
 
 	_, err = p.processStream(&testStream2)

--- a/processor_metrics_test.go
+++ b/processor_metrics_test.go
@@ -169,7 +169,7 @@ func createProcessor() (*processor, error) {
 		return nil, err
 	}
 
-	return newProcessor(*cfg), nil
+	return newProcessor(*cfg)
 }
 
 func sinkHandlerError(ctx *fh.RequestCtx) {
@@ -223,7 +223,7 @@ func Test_request_headers(t *testing.T) {
 	cfg, err := getConfig(testConfig)
 	assert.Nil(t, err)
 
-	p := newProcessor(*cfg)
+	p, _ := newProcessor(*cfg)
 
 	req := fh.AcquireRequest()
 	clientIP, _ := net.ResolveIPAddr("ip", "1.1.1.1")
@@ -242,7 +242,7 @@ func Test_handle(t *testing.T) {
 	cfg.pipeOut = fhu.NewInmemoryListener()
 	cfg.Tenant.LabelRemove = true
 
-	p := newProcessor(*cfg)
+	p, _ := newProcessor(*cfg)
 	err = p.run()
 	assert.Nil(t, err)
 
@@ -384,7 +384,7 @@ func Test_processTimeseries(t *testing.T) {
 	assert.Nil(t, err)
 	cfg.Tenant.LabelRemove = true
 
-	p := newProcessor(*cfg)
+	p, _ := newProcessor(*cfg)
 	assert.Nil(t, err)
 
 	ten, err := p.processTimeseries(&testTS4)
@@ -396,7 +396,7 @@ func Test_processTimeseries(t *testing.T) {
 	assert.Equal(t, "default", ten)
 
 	cfg.Tenant.Default = ""
-	p = newProcessor(*cfg)
+	p, _ = newProcessor(*cfg)
 	assert.Nil(t, err)
 
 	_, err = p.processTimeseries(&testTS3)


### PR DESCRIPTION
This PR:
- Adds a new configuration option to explicitly set the trusted CA (`CT_CA_BUNDLE_FILE` / `auth.egress.tls_config.ca_bundle_file`)
- Adds support for setting this configuration option via the Helm chart via a new chart value. `config.ca_bundle_file`.
- Amends the existing Helm functionality (configured via the `customCA` value) to use the configuration option rather than mounting the CA as a system trust root for the container.

This approach is preferable to the previous (`customCA`) behaviour because now when setting a CA it, _and only it_, will be trusted. Previously the new CA would be trusted but so would all the default trust roots bundled with the container. Explicitly limiting the desired trusted CA bundle is preferable for some security setups.

Additionally, the helm chart continues to support both the `customCA` method _and_ more explicit configuration via `config.ca_bundle_file` to support cases where the application wants to use a non-secret based certificate (such as a trust bundle injected in via the runtime, kubelet, serviceaccount CA, etc...)

By adding the `tls_config` configuration block, I hope to submit feature PRs adding support for client TLS certs to upstream, and TLS support for the server itself.

As a side effect, this PR changes the return signature of the private `newProcessor()` method from `(*processor)` to `(*processor, error)`. The tests have been updated to match. As TLS functionality is implemented in fasthttp - this PR simply turns it on - no specific test for TLS support has been added.