### PR TITLE
TLS server Support

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,6 +40,12 @@ type config struct {
 				CaBundleFile string `yaml:"ca_bundle_file" env:"CT_CA_BUNDLE_FILE"`
 			} `yaml:"tls_config"`
 		}
+		Ingress struct {
+			TlsConfig struct {
+				CertFile string `yaml:"cert_file" env:"CT_TLS_CERT_FILE"`
+				KeyFile  string `yaml:"key_file" env:"CT_TLS_KEY_FILE"`
+			} `yaml:"tls_config"`
+		}
 	}
 
 	Tenant struct {

--- a/deploy/k8s/chart/README.md
+++ b/deploy/k8s/chart/README.md
@@ -20,6 +20,10 @@ A Helm Chart for cortex-tenant
 | autoscaling.targetCPUUtilizationPercentage | int | `60` | Target CPU utilization percentage for autoscaling |
 | autoscaling.targetMemoryUtilizationPercentage | int | `60` | Target memory utilization percentage for autoscaling |
 | config.ca_bundle_file | string | `null` | If set, this file is loaded as the CA Bundle for verifying TLS certificates sent by the upstream server |
+| config.tls.enabled | bool | `false` | If true the service will accept TLS traffic. Otherwise plain HTTP. |
+| config.tls.cert_file | string | `"/var/run/pki/tls.crt"` | The path to the certificate file within the container |
+| config.tls.key_file | string | `"/var/run/pki/tls.key"` | The path to the private key file within the container |
+| config.tls.existingSecret | string | `null` | Secret should be of type kubernetes.io/tls with tls.key and tls.crt entries |
 | config.auth.enabled | bool | `false` | Egress HTTP basic auth -> add `Authentication` header to outgoing requests |
 | config.auth.existingSecret | string | `nil` | Secret should pass the `CT_AUTH_EGRESS_USERNAME` and `CT_AUTH_EGRESS_PASSWORD` env variables |
 | config.auth.password | string | `nil` | Password (env: `CT_AUTH_EGRESS_PASSWORD`) |

--- a/deploy/k8s/chart/templates/configmap.yaml
+++ b/deploy/k8s/chart/templates/configmap.yaml
@@ -30,6 +30,14 @@ data:
         username: {{ .Values.config.auth.username }}
         password: {{ .Values.config.auth.password }}
         {{- end }}
+      {{- with .Values.config.tls }}
+      {{- if .enabled }}
+      ingress:
+        tls_config:
+          cert_file: {{ .cert_file }}
+          key_file: {{ .key_file }}
+      {{- end }}
+      {{- end }}
     tenant:
       label: {{ .Values.config.tenant.label }}
       {{- with .Values.config.tenant.label_list }}

--- a/deploy/k8s/chart/templates/deployment.yaml
+++ b/deploy/k8s/chart/templates/deployment.yaml
@@ -94,6 +94,18 @@ spec:
               name: ca-bundle
               subPath: {{ .Values.customCA.subPath | default "ca.crt" }}
             {{- end }}
+            {{- with .Values.config.tls }}
+            {{- if and .enabled .existingSecret }}
+            - mountPath: {{ .cert_file }}
+              name: tls-certs
+              subPath: tls.crt
+              readOnly: true
+            - mountPath: {{ .key_file }}
+              name: tls-certs
+              subPath: tls.key
+              readOnly: true
+            {{- end }}
+            {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
@@ -105,6 +117,13 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ .Values.customCA.secretName | default "ca-bundle" }}
+        {{- end }}
+        {{- with .Values.config.tls }}
+        {{- if and .enabled .existingSecret }}
+        - name: tls-certs
+          secret:
+            secretName: {{ .existingSecret }}
+        {{- end }}
         {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/deploy/k8s/chart/values.schema.json
+++ b/deploy/k8s/chart/values.schema.json
@@ -243,6 +243,35 @@
           "title": "CA Bundle File",
           "description": "If set, this file is loaded as the CA Bundle for verifying TLS certificates sent by the upstream server"
         },
+        "tls": {
+          "type": "object",
+          "title": "TLS Configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled",
+              "description": "If true the service will accept TLS traffic. Otherwise plain HTTP."
+            },
+            "cert_file": {
+              "type": "string",
+              "title": "TLS Certificate Path",
+              "description": "The path to the certificate file within the container"
+            },
+            "key_file": {
+              "type": "string",
+              "title": "TLS Key Path",
+              "description": "The path to the private key file within the container"
+            },
+            "existingSecret": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "title": "Existing Secret",
+              "description": "Secret should be of type kubernetes.io/tls with tls.key and tls.crt entries"
+            }
+          }
+        },
         "auth": {
           "type": "object",
           "title": "Authentication",

--- a/deploy/k8s/chart/values.yaml
+++ b/deploy/k8s/chart/values.yaml
@@ -101,6 +101,22 @@ config:
   # (env: `CT_CA_BUNDLE_FILE`)
   ca_bundle_file:
 
+  tls:
+    # -- Ingress TLS
+    # If set the service will accept TLS traffic. Otherwise plain HTTP.
+    enabled: false
+
+    # -- TLS Certificate Path
+    # (env: `CT_TLS_CERT_FILE`)
+    cert_file: /var/run/pki/tls.crt
+
+    # -- TLS Key Path
+    # (env: `CT_TLS_KEY_FILE`)
+    key_file: /var/run/pki/tls.key
+
+    # -- Secret should be of type kubernetes.io/tls with tls.key and tls.crt entries.
+    existingSecret:
+
   # Authentication (optional)
   auth:
     # -- Egress HTTP basic auth -> add `Authentication` header to outgoing requests

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/dyson/certman v0.3.0 // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/edsrzf/mmap-go v1.2.0 // indirect
 	github.com/efficientgo/core v1.0.0-rc.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/dyson/certman v0.3.0 h1:S7WCUim5faT/OiBhiY3u5cMaiC9MNKiA+8PJDXLaIYQ=
+github.com/dyson/certman v0.3.0/go.mod h1:RMWlyA9op6D9SxOBRRX3sxnParehv9gf52WWUJPd1JA=
 github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
 github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=

--- a/processor.go
+++ b/processor.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/blind-oracle/go-common/logger"
+	"github.com/dyson/certman"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	fh "github.com/valyala/fasthttp"
@@ -58,6 +59,8 @@ func newProcessor(c config) (*processor, error) {
 		IdleTimeout:  c.IdleTimeout,
 
 		Concurrency: c.Concurrency,
+
+		TLSConfig: &tls.Config{},
 	}
 
 	p.cli = &fh.Client{
@@ -87,6 +90,22 @@ func newProcessor(c config) (*processor, error) {
 		p.auth.egressHeader = []byte("Basic " + base64.StdEncoding.EncodeToString(authString))
 	}
 
+	if c.Auth.Ingress.TlsConfig.CertFile != "" && c.Auth.Ingress.TlsConfig.KeyFile != "" {
+		cm, err := certman.New(
+			c.Auth.Ingress.TlsConfig.CertFile,
+			c.Auth.Ingress.TlsConfig.KeyFile,
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "Unable to configure server TLS")
+		}
+		err = cm.Watch()
+		if err != nil {
+			return nil, errors.Wrap(err, "Unable to configure server TLS")
+		}
+
+		p.srv.TLSConfig.GetCertificate = cm.GetCertificate
+	}
+
 	// For testing
 	if c.pipeOut != nil {
 		p.cli.Dial = func(a string) (net.Conn, error) {
@@ -109,7 +128,13 @@ func (p *processor) run() (err error) {
 		l = p.cfg.pipeIn
 	}
 
-	go p.srv.Serve(l)
+	if p.srv.TLSConfig.GetCertificate == nil {
+		go p.srv.Serve(l)
+	} else {
+		// Just pass empty certFile and keyFile to serveTLS because we have
+		// overriden the static behaviour with CertMan in the processor setup.
+		go p.srv.ServeTLS(l, "", "")
+	}
 	return
 }
 

--- a/processor_config_test.go
+++ b/processor_config_test.go
@@ -148,28 +148,52 @@ func Test_CABundleFileFail(t *testing.T) {
 	require.Error(t, err)
 }
 
+// Signs the given certificate after adding some sensible required
+// values
+func signCert(t *testing.T, cert, parent *x509.Certificate, pubKey, caPriv any) []byte {
+	cert.NotBefore = time.Now().UTC()
+	cert.NotAfter = time.Now().Add(5 * time.Minute).UTC()
+	cert.BasicConstraintsValid = true
+
+	signed, err := x509.CreateCertificate(rand.Reader, cert, parent, pubKey, caPriv)
+	require.NoError(t, err)
+
+	return signed
+}
+
+// Generates a private key pair for testing
+func makePrivateKey(t *testing.T) (any, any) {
+	pubKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	return pubKey, privateKey
+}
+
 // Generates a self signed CA for testing
-//
-// NB: The generated cert does not have the appropraite fields to be useful
-// for anything.
-func generateCA(t *testing.T, w io.Writer, cn string) string {
+func generateCA(t *testing.T, cn string) ([]byte, any) {
 	cert := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName: cn,
 		},
+		IsCA: true,
 	}
-	pubKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
-	require.NoError(t, err)
+	pubKey, privateKey := makePrivateKey(t)
 
-	signed, err := x509.CreateCertificate(rand.Reader, &cert, &cert, pubKey, privateKey)
-	require.NoError(t, err)
+	return signCert(t, &cert, &cert, pubKey, privateKey), privateKey
+}
+
+// Generates a self signed CA and writes it to the given writer
+//
+// It returns the string representation of the subject
+func generateAndWriteCA(t *testing.T, w io.Writer, cn string) string {
+	signed, _ := generateCA(t, cn)
 
 	require.NoError(t, pem.Encode(w, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: signed,
 	}))
 
-	return cert.Subject.String()
+	return "CN=" + cn
 }
 
 // Tests that when a CA Bundle file is given its certs are loaded into the client
@@ -186,8 +210,8 @@ func Test_CABundleFile(t *testing.T) {
 	require.NoError(t, err)
 
 	generatedSubjects := []string{
-		generateCA(t, f, "Test 1"),
-		generateCA(t, f, "Test 2"),
+		generateAndWriteCA(t, f, "Test 1"),
+		generateAndWriteCA(t, f, "Test 2"),
 	}
 
 	p, err := newProcessor(cfg)

--- a/processor_config_test.go
+++ b/processor_config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -248,4 +249,131 @@ func Test_NoCABundleFile(t *testing.T) {
 	// Empty RootCAs means the TLSConfig will fall back to using system trust
 	// certs, as desired.
 	require.Nil(t, p.cli.TLSConfig.RootCAs)
+}
+
+// Runs the processor, requiring that it succeeds, and registering a cleanup
+// function to shut it down again after the test.
+func runProcessor(t *testing.T, p *processor) {
+	require.NoError(t, p.run())
+	t.Cleanup(func() {
+		p.close()
+	})
+}
+
+// Tests that when no CertFile / KeyFile are specified, the server listens
+// in plain HTTP
+func Test_NoTls(t *testing.T) {
+	cfg := config{}
+	cfg.pipeIn = fhu.NewInmemoryListener()
+
+	cfg.Auth.Ingress.TlsConfig.CertFile = ""
+	cfg.Auth.Ingress.TlsConfig.KeyFile = ""
+
+	p, err := newProcessor(cfg)
+	require.NoError(t, err)
+
+	c := &fh.Client{
+		Dial: func(_ string) (net.Conn, error) {
+			return cfg.pipeIn.Dial()
+		},
+	}
+
+	runProcessor(t, p)
+
+	req := fh.AcquireRequest()
+
+	// Expect this to be accessible over HTTP (no TLS)
+	req.SetRequestURI("http://test/alive")
+	require.NoError(t, c.Do(req, nil))
+
+	// Expect this to be inaccessible over HTTPS (no TLS)
+	req.SetRequestURI("https://test/alive")
+	require.Error(t, c.Do(req, nil))
+}
+
+// Makes and write a PEM block to a given file
+func makeAndWrite(t *testing.T, name, pemType string, content []byte) {
+	f, err := os.Create(name)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.Remove(name)
+	})
+
+	require.NoError(t, pem.Encode(f, &pem.Block{
+		Type:  pemType,
+		Bytes: content,
+	}))
+	f.Close()
+}
+
+// Creates a cert and key for the "test" service, signed by the given CA
+func makeCertKeyPair(t *testing.T, ca *x509.Certificate, caPriv any) {
+	cert := x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "test",
+		},
+		DNSNames: []string{"test"},
+	}
+	pubKey, privateKey := makePrivateKey(t)
+
+	makeAndWrite(t,
+		"/tmp/tls.crt",
+		"CERTIFICATE",
+		signCert(t, &cert, ca, pubKey, caPriv),
+	)
+
+	marshalledKey, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	require.NoError(t, err)
+	makeAndWrite(t, "/tmp/tls.key", "PRIVATE KEY", marshalledKey)
+}
+
+// Tests that when CertFile / KeyFile are specified, the server listens
+// using TLS
+func Test_Tls(t *testing.T) {
+	signed, privateKey := generateCA(t, "Test CA")
+
+	ca, err := x509.ParseCertificate(signed)
+	require.NoError(t, err)
+
+	makeCertKeyPair(t, ca, privateKey)
+
+	cfg := config{}
+	cfg.Auth.Ingress.TlsConfig.CertFile = "/tmp/tls.crt"
+	cfg.Auth.Ingress.TlsConfig.KeyFile = "/tmp/tls.key"
+	cfg.pipeIn = fhu.NewInmemoryListener()
+
+	p, err := newProcessor(cfg)
+	require.NoError(t, err)
+
+	c := &fh.Client{
+		Dial: func(_ string) (net.Conn, error) {
+			return cfg.pipeIn.Dial()
+		},
+		TLSConfig: &tls.Config{
+			RootCAs: x509.NewCertPool(),
+		},
+	}
+	c.TLSConfig.RootCAs.AddCert(ca)
+
+	runProcessor(t, p)
+
+	req := fh.AcquireRequest()
+
+	// Expect this to be inaccessible over HTTP (because it is TLS)
+	req.SetRequestURI("http://test/alive")
+	require.Error(t, c.Do(req, nil))
+
+	// Expect this to be accessible over HTTPS (because it is TLS)
+	req.SetRequestURI("https://test/alive")
+	require.NoError(t, c.Do(req, nil))
+}
+
+func Test_TlsFail(t *testing.T) {
+	cfg := config{}
+	cfg.Auth.Ingress.TlsConfig.CertFile = "file_does_not_exist.crt"
+	cfg.Auth.Ingress.TlsConfig.KeyFile = "file_does_not_exist.key"
+
+	_, err := newProcessor(cfg)
+	require.Error(t, err)
 }


### PR DESCRIPTION
This PR adds TLS support and associated tests for the server component of cortex-tenant, allowing downstream clients to send metrics encrypted rather than in plaintext.

## Config

This is configured via the new config block:

```yaml
auth:
  ingress:
    tls_config:
      # Or env: CT_TLS_CERT_FILE
      cert_file:
      # Or env: CT_TLS_KEY_FILE
      key_file:
```

## Helm

Additionally, this adds matching support via the helm file with the following values:

```yaml
config:
  tls:
    enabled: false
    cert_file: "/var/run/pki/tls.crt"
    key_file: "/var/run/pki/tls.key"
    existingSecret:
```

When `existingSecret` is set, this should be of the standard type `kubernetes.io/tls` with `"tls.crt"` and `"tls.key"` entries. If `existingSecret` is unset but `enabled` is true, the helm chart will assume the relevant files are mounted inside the container via some other method (eg runtime, CSI, mutating policy etc) to support whatever pre-existing non-secret based certificate management users may already be using.

## Implementation

I have used `dyson/certman` to monitor / watch the given cert file and key files - this allows fasthttp to pick up certificate changes at runtime if it is reissued, without needing to restart the whole server whenever the certificates are rotated.